### PR TITLE
Implement basic sub-workflows

### DIFF
--- a/core/pipeline/io.py
+++ b/core/pipeline/io.py
@@ -11,3 +11,26 @@ def make_paths(subject_id):
     t1_path    = f"/data/rawdata-archive/IndivConn/{subject_id}/anat/{subject_id}_T1w.nii.gz"
     atlas_path = "/data/atlases/Schaefer2018_400Parcels.nii.gz"
     return t1_path, atlas_path
+
+
+def io_workflow(config):
+    """Return a simple workflow that discovers file paths."""
+    from nipype import Workflow, Node
+    from nipype.interfaces.utility import Function
+
+    wf = Workflow(name="io_workflow")
+
+    node = Node(
+        Function(
+            input_names=["subject_id"],
+            output_names=["t1_path", "atlas_path"],
+            function=make_paths,
+        ),
+        name="make_paths",
+    )
+
+    subject_id = config.get("APP", "subject_id", fallback="")
+    node.inputs.subject_id = subject_id
+
+    wf.add_nodes([node])
+    return wf

--- a/core/pipeline/main_workflow.py
+++ b/core/pipeline/main_workflow.py
@@ -13,21 +13,34 @@ class MainWorkflow(Workflow):
         from core.pipeline.io import io_workflow
         wf_io = io_workflow(config)
         # Pull all nodes from the I/O workflow into this one
-        self.add_nodes(wf_io.nodes)
+        self.add_nodes(wf_io._get_all_nodes())
 
         # 2) Parcellation step
         from core.pipeline.parcellation import parc_workflow
         wf_parc = parc_workflow(config)
-        self.add_nodes(wf_parc.nodes)
+        self.add_nodes(wf_parc._get_all_nodes())
 
         # 3) Subject‐dict assembly
         from core.pipeline.subjectdict import subjectdict_workflow
         wf_sd = subjectdict_workflow(config)
-        self.add_nodes(wf_sd.nodes)
+        self.add_nodes(wf_sd._get_all_nodes())
 
-        # (Optional) if you need to connect outputs of one to inputs of another:
-        # self.connect([
-        #     (wf_io.get_node('output'), 't1_file',
-        #      wf_parc.get_node('input'), 't1_file'),
-        #     # ... etc.
-        # ])
+        # Connect outputs between sub-workflows
+        self.connect([
+            (
+                wf_io.get_node('make_paths'),
+                wf_parc.get_node('apply_parcellation'),
+                [('t1_path', 't1_path'), ('atlas_path', 'atlas_path')],
+            ),
+            (
+                wf_io.get_node('make_paths'),
+                wf_sd.get_node('build_subject_dict'),
+                [('t1_path', 't1_path')],
+            ),
+            (
+                wf_parc.get_node('apply_parcellation'),
+                wf_sd.get_node('build_subject_dict'),
+                [('label_map', 'label_map')],
+            ),
+        ])
+

--- a/core/pipeline/parcellation.py
+++ b/core/pipeline/parcellation.py
@@ -16,3 +16,25 @@ def apply_parcellation(t1_path, atlas_path, out_dir="."):
     #       e.g. `singularity exec fsl.simg flirt ... -o out_path`
     # For now, just pretend the file was created:
     return out_path
+
+
+def parc_workflow(config):
+    """Return a workflow that runs the parcellation step."""
+    from nipype import Workflow, Node
+    from nipype.interfaces.utility import Function
+
+    wf = Workflow(name="parc_workflow")
+
+    node = Node(
+        Function(
+            input_names=["t1_path", "atlas_path", "out_dir"],
+            output_names=["label_map"],
+            function=apply_parcellation,
+        ),
+        name="apply_parcellation",
+    )
+
+    node.inputs.out_dir = config.get("PATHS", "output_dir", fallback=".")
+
+    wf.add_nodes([node])
+    return wf

--- a/core/pipeline/subjectdict.py
+++ b/core/pipeline/subjectdict.py
@@ -10,3 +10,25 @@ def build_subject_dict(subject_id, t1_path, label_map):
         "label_map": label_map,
         # later: add {roi_index: feature_value} here
     }
+
+
+def subjectdict_workflow(config):
+    """Return a workflow that assembles the subject dictionary."""
+    from nipype import Workflow, Node
+    from nipype.interfaces.utility import Function
+
+    wf = Workflow(name="subjectdict_workflow")
+
+    node = Node(
+        Function(
+            input_names=["subject_id", "t1_path", "label_map"],
+            output_names=["subject_dict"],
+            function=build_subject_dict,
+        ),
+        name="build_subject_dict",
+    )
+
+    node.inputs.subject_id = config.get("APP", "subject_id", fallback="")
+
+    wf.add_nodes([node])
+    return wf


### PR DESCRIPTION
## Summary
- add nipype workflows for I/O, parcellation, and subject dictionary
- connect sub-workflows inside `MainWorkflow`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fb88fa3548320b5ddd67989957742