### PR TITLE
Update workflow connections

### DIFF
--- a/core/pipeline/parc_workflow.py
+++ b/core/pipeline/parc_workflow.py
@@ -8,6 +8,10 @@ from nipype import Workflow, Node, Function
 def apply_parcellation(t1_path: str, atlas_path: str, out_dir: str = "."):
     """Return the expected output label map path (placeholder)."""
 
+    # Function nodes execute in a new Python context.  Import dependencies
+    # inside the function so they are available when the node runs.
+    from pathlib import Path
+
     atlas_base = Path(atlas_path).with_suffix("").stem
     out_fname = f"{atlas_base}_in_subject.nii.gz"
     out_path = str(Path(out_dir) / out_fname)


### PR DESCRIPTION
## Summary
- simplify connection syntax between subworkflows
- ensure ConfigManager doesn't override workflow config
- make parcellation function import dependencies when run inside a node

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'EOF'
from core.config.config_manager import ConfigManager
from core.pipeline.main_workflow import MainWorkflow
cfg = ConfigManager('toolbox.ini')
wf = MainWorkflow(cfg)
wf.base_dir = cfg.get('PATHS', 'output_dir', fallback='./results')
wf.run()
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685fdc3786dc8320a55b2f6f59caab96