### PR TITLE
Add linear registration workflow

### DIFF
--- a/core/__main__.py
+++ b/core/__main__.py
@@ -5,6 +5,7 @@ from core.config.config_manager import ConfigManager
 
 from core.pipeline.io_workflow           import make_paths
 from core.pipeline.parc_workflow import apply_parcellation
+from core.pipeline.linear_reg_workflow import linear_register
 from core.pipeline.subjectdict_workflow  import build_subject_dict
 
 def main():
@@ -42,7 +43,16 @@ def main():
     label_map = apply_parcellation(t1_path, atlas_path, out_dir=out_dir)
     print("    Label map →", label_map)
 
-    # 5) Build subject dict
+    # 5) Register additional image if provided
+    moving_img = cfg.get("PATHS", "moving_image", fallback="")
+    if moving_img:
+        print("Registering additional image…")
+        registered = linear_register(moving_img, t1_path, out_dir=out_dir)
+        print("    Registered →", registered)
+    else:
+        print("No moving_image set – skipping registration")
+
+    # 6) Build subject dict
     print("Building subject dictionary…")
     subj_dict = build_subject_dict(subj, t1_path, label_map)
     print("    Subject dict →", subj_dict)

--- a/core/config/config_manager.py
+++ b/core/config/config_manager.py
@@ -21,7 +21,8 @@ class ConfigManager:
             "output_dir": "./results",
             "bids_root": "",
             "atlas_path": "",
-            "reference_T1": ""
+            "reference_T1": "",
+            "moving_image": ""
             # reference_T1 wird noch nicht verwended/gebraucht. Muss noch referenziert werden in __main__ bwz. .ini
         }
 

--- a/core/pipeline/linear_reg_workflow.py
+++ b/core/pipeline/linear_reg_workflow.py
@@ -1,0 +1,63 @@
+"""Simple linear registration workflow using FSL's FLIRT."""
+from pathlib import Path
+import os
+import shutil
+import subprocess
+
+from nipype import Workflow, Node, Function
+
+
+def linear_register(moving_image: str, reference_image: str, out_dir: str = "."):
+    """Register ``moving_image`` to ``reference_image`` using FLIRT."""
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    base = Path(moving_image).with_suffix("").stem
+    out_path = str(out_dir / f"{base}_reg.nii.gz")
+
+    def get_cmd(tool: str):
+        local = shutil.which(tool)
+        img = os.environ.get("FSL_SINGULARITY_IMAGE")
+        if img:
+            return ["singularity", "exec", img, tool]
+        if local:
+            return [local]
+        raise RuntimeError(
+            f"{tool} not found – install FSL or set FSL_SINGULARITY_IMAGE"
+        )
+
+    cmd = get_cmd("flirt") + [
+        "-in",
+        moving_image,
+        "-ref",
+        reference_image,
+        "-out",
+        out_path,
+        "-interp",
+        "trilinear",
+        "-cost",
+        "mutualinfo",
+        "-dof",
+        "6",
+    ]
+    subprocess.run(cmd, check=True)
+    return out_path
+
+
+def linear_reg_workflow(config):
+    """Create a Nipype workflow for linear registration."""
+    wf = Workflow(name="linear_reg_workflow")
+
+    reg_node = Node(
+        Function(
+            input_names=["moving_image", "reference_image", "out_dir"],
+            output_names=["registered_file"],
+            function=linear_register,
+        ),
+        name="linear_register",
+    )
+
+    reg_node.inputs.moving_image = config.get("PATHS", "moving_image", fallback="")
+    reg_node.inputs.out_dir = config.get("PATHS", "output_dir", fallback=".")
+
+    wf.add_nodes([reg_node])
+    return wf

--- a/core/pipeline/main_workflow.py
+++ b/core/pipeline/main_workflow.py
@@ -19,7 +19,12 @@ class MainWorkflow(Workflow):
         wf_parc = parc_workflow(config)
         self.add_nodes([wf_parc])
 
-        # 3) Subject‐dict assembly
+        # 3) Linear registration of additional image
+        from core.pipeline.linear_reg_workflow import linear_reg_workflow
+        wf_reg = linear_reg_workflow(config)
+        self.add_nodes([wf_reg])
+
+        # 4) Subject‐dict assembly
         from core.pipeline.subjectdict_workflow import subjectdict_workflow
         wf_sd = subjectdict_workflow(config)
         self.add_nodes([wf_sd])
@@ -30,6 +35,8 @@ class MainWorkflow(Workflow):
              wf_parc.get_node('apply_parcellation'), 't1_path'),
             (wf_io.get_node('make_paths'), 'atlas_path',
              wf_parc.get_node('apply_parcellation'), 'atlas_path'),
+            (wf_io.get_node('make_paths'), 't1_path',
+             wf_reg.get_node('linear_register'), 'reference_image'),
             (wf_io.get_node('make_paths'), 't1_path',
              wf_sd.get_node('build_subject_dict'), 't1_path'),
             (wf_parc.get_node('apply_parcellation'), 'label_map',

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -66,6 +66,26 @@ def test_apply_parcellation(monkeypatch, tmp_path):
     # two commands should be executed: bet and flirt
     assert len(calls) == 2
 
+def test_linear_register(monkeypatch, tmp_path):
+    mod = importlib.import_module('core.pipeline.linear_reg_workflow')
+    linear_register = mod.linear_register
+
+    true_cmd = shutil.which('true') or '/bin/true'
+    def fake_which(tool):
+        return true_cmd
+    monkeypatch.setattr(shutil, 'which', fake_which)
+
+    calls = []
+    def fake_run(cmd, check):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    out = linear_register('img.nii.gz', 'ref.nii.gz', out_dir=tmp_path)
+    expected = tmp_path / 'img_reg.nii.gz'
+    assert Path(out) == expected
+    assert len(calls) == 1
+
 def test_build_subject_dict(monkeypatch):
     mod = importlib.import_module('core.pipeline.subjectdict_workflow')
     build_subject_dict = mod.build_subject_dict

--- a/toolbox.ini
+++ b/toolbox.ini
@@ -8,6 +8,8 @@ output_dir = ./results
 bids_root =
 atlas_path = /data/env/parcellations_atlases/AtlasPack/Schaefer/tpl-MNI152NLin6Asym_atlas-Schaefer2018v0143_res-01_desc-400ParcelsAllNetworks_dseg.nii.gz
 reference_T1 = /data/rawdata-archive/IndivConn/sub-IndivConn000002/ses-01/anat/sub-IndivConn000002_ses-01_run-01_T1w.nii.gz
+# Path to an additional modality to register to the T1
+moving_image =
 # reference_T1 wird noch nicht verwended/gebraucht. Muss noch referenziert werden
 
 [FSL]


### PR DESCRIPTION
## Summary
- add a simple FLIRT-based linear registration workflow
- support configuration of an optional `moving_image`
- run the registration step in `__main__` and in `MainWorkflow`
- test the new workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3631e5488320b364b5f63f1a97a2