### PR TITLE
Enable execution of linear registration workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ Pipeline Overview
 	•	Volumetric overlay on T1 slices
 	•	Surface rendering or 3D node plot
 	•	Optional edges for connectivity
+
+Running the registration workflow
+---------------------------------
+1. Configure paths in `toolbox.ini` (subject ID, atlas, output directory).
+2. Ensure FSL is installed or provide the Singularity image path.
+3. Run `python -m core` to execute the workflow.
+   Outputs will be written to `output_dir/output/`.

--- a/core/__main__.py
+++ b/core/__main__.py
@@ -50,8 +50,10 @@ def main():
     base_dir            = out_dir                            # where nipype writes its work/
     is_volumetric       = True                               # you only do 3D
     is_partial_coverage = False 
-    label_map = linear_reg_workflow (name, t1_path, config, base_dir, is_volumetric, is_partial_coverage)
-    print("    Label map →", label_map)
+    label_map = linear_reg_workflow(name, t1_path, config, base_dir, is_volumetric, is_partial_coverage)
+    print("Running registration workflow…")
+    label_map.run()
+    print("    Workflow outputs stored in", os.path.join(base_dir, "output"))
 
     # 5) Build subject dict
     print("Building subject dictionary…")

--- a/core/pipeline/parc_workflow.py
+++ b/core/pipeline/parc_workflow.py
@@ -1,6 +1,7 @@
 # Trying to implement SWANe Code 
 
 from nipype.interfaces.fsl import (BET, FLIRT, RobustFOV, ApplyXFM, ApplyMask)
+import os
 from core.utils.CustomWorkflow import CustomWorkflow
 #from core.utils.CustomDcm2niix import CustomDcm2niix
 from core.utils.ForceOrient import ForceOrient
@@ -168,5 +169,11 @@ def linear_reg_workflow(name: str, t1_path: str, config: SectionProxy, base_dir:
         workflow.connect(flirt_2_ref, "out_file", outputnode, "betted_registered_file")
         workflow.connect(unbet_flirt, "out_file", outputnode, "registered_file")
         workflow.connect(flirt_2_ref, "out_matrix_file", outputnode, "out_matrix_file")
-    
+
+    # Store results in an "output" folder inside the workflow base directory
+    sink_path = os.path.join(base_dir, "output")
+    workflow.sink_result(sink_path, 'outputnode', 'registered_file', 'registered_file')
+    workflow.sink_result(sink_path, 'outputnode', 'betted_registered_file', 'betted_registered_file')
+    workflow.sink_result(sink_path, 'outputnode', 'out_matrix_file', 'out_matrix_file')
+
     return workflow


### PR DESCRIPTION
## Summary
- run the `linear_reg_workflow` directly from `core.__main__`
- store workflow results in an `output` folder
- document how to launch the workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a3f8e0d788320ad17cf6911c41b32